### PR TITLE
Extend news features with bounding box info

### DIFF
--- a/modelPart1/utils.py
+++ b/modelPart1/utils.py
@@ -876,7 +876,10 @@ def get_node_related_news_tensor(nodes, UN_PRED_NEWS, PRED_NEWS, max_news_num=10
       PRED_NEWS: pd.read_csv(predictable.csv) 的测试集/训练集
       max_num: 每个节点最多选择的新闻数量
     return:
-      torch.Tensor shape (idx_of_nodes, idx_of_news, 8); 8: 2(event_time, delta_t) + 6(scores)
+      torch.Tensor shape (idx_of_nodes, idx_of_news, 16)
+      2(event_time, delta_t) + 6(scores) +
+      4(north, south, east, west) +
+      4(north-lat, south-lat, east-lon, west-lon)
     """
     cols = ["event_time", "north", "south", "east", "west"] + [f"score_{i}" for i in range(6)]
     up_arr  = UN_PRED_NEWS[cols].values
@@ -886,7 +889,7 @@ def get_node_related_news_tensor(nodes, UN_PRED_NEWS, PRED_NEWS, max_news_num=10
     pr_times = pr_arr[:,0]
 
     num_nodes = len(nodes)
-    out = torch.zeros((num_nodes, max_news_num, 7), dtype=torch.float32)
+    out = torch.zeros((num_nodes, max_news_num, 16), dtype=torch.float32)
 
     for idx, node in enumerate(nodes):
         t, lat, lon = node["timestamp"], node["latitude"], node["longitude"]
@@ -908,9 +911,20 @@ def get_node_related_news_tensor(nodes, UN_PRED_NEWS, PRED_NEWS, max_news_num=10
             hits = hits[:max_news_num]
             times    = hits[:, 0:1]
             delta_t  = times - t
+            north    = hits[:, 1:2]
+            south    = hits[:, 2:3]
+            east     = hits[:, 3:4]
+            west     = hits[:, 4:5]
             scores   = hits[:, 5:11]
+
+            # 差值特征：新闻范围与节点位置的差
+            diff_feat = np.hstack((north - lat,
+                                   south - lat,
+                                   east - lon,
+                                   west - lon))
+
             tensor   = torch.tensor(
-                np.hstack((times, delta_t, scores)),
+                np.hstack((times, delta_t, scores, north, south, east, west, diff_feat)),
                 dtype=torch.float32
             )
 


### PR DESCRIPTION
## Summary
- expand news feature vector in `get_node_related_news_tensor`
  - include bounding box values (north, south, east, west)
  - include differences between news coordinates and node coordinates
- update output tensor dimension documentation

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6840082bc2c08331ab9dd5411ecfcae5