### PR TITLE
Update ETA training sampling logic

### DIFF
--- a/modelPart1/train_eta.py
+++ b/modelPart1/train_eta.py
@@ -95,8 +95,21 @@ def main(cfg):
     # ---------- (Optional) resume ----------
     start_ep = 1
     if cfg.resume and Path(cfg.resume).exists():
-        start_ep = load_ckpt(Path(cfg.resume), Aemb, shipemb, nearemb, mdl, optim, scaler, device) + 1
-        print(f"🔄 Resume from epoch {start_ep}")
+        start_ep = load_ckpt(
+            Path(cfg.resume),
+            Aemb,
+            shipemb,
+            nearemb,
+            mdl,
+            optim,
+            scaler,
+            device,
+            strict=False,
+        ) + 1
+        # 允许重新指定学习率等可调参数
+        for g in optim.param_groups:
+            g['lr'] = cfg.lr
+        print(f"🔄 Resume from epoch {start_ep} (lr={cfg.lr}, use_news={cfg.use_news})")
 
     # ---------- Train loop ----------
     best_val = float('inf')
@@ -226,7 +239,8 @@ if __name__ == "__main__":
     pa.add_argument('--k_near', type=int, default=32)
     pa.add_argument('--h_ship', type=int, default=10)
     pa.add_argument('--radius', type=float, default=50.0)
-    pa.add_argument('--step', type=int, default=32, help="Sampling step of the voyage(1=each node)")
+    pa.add_argument('--step', type=int, default=32,
+                    help="Maximum number of B nodes sampled from a voyage path")
     pa.add_argument('--clip', type=float, default=0.0)
     pa.add_argument('--amp', action='store_true', help="Use AMP")
     pa.add_argument('--seed', type=int, default=22)

--- a/modelPart1/utils.py
+++ b/modelPart1/utils.py
@@ -49,14 +49,37 @@ def save_ckpt(ep, Aemb, shipemb, nearemb, mdl, opt, scaler, path: Path):
 
 
 
-def load_ckpt(path: Path, Aemb, shipemb, nearemb, mdl, opt, scaler, device):
+def load_ckpt(path: Path,
+              Aemb,
+              shipemb,
+              nearemb,
+              mdl,
+              opt=None,
+              scaler=None,
+              device=None,
+              *,
+              strict: bool = True):
+    """Load checkpoint and restore module states.
+
+    Parameters
+    ----------
+    strict : bool, optional
+        When ``False`` mismatched keys in state dicts are ignored so that
+        models with modified structures can still load available weights.
+    """
+
     ckpt = torch.load(str(path), map_location=device)
-    Aemb.load_state_dict(ckpt['Aemb'])
-    shipemb.load_state_dict(ckpt['shipemb'])
-    nearemb.load_state_dict(ckpt['nearemb'])
-    mdl.load_state_dict(ckpt['model'])
-    opt.load_state_dict(ckpt['optim'])
-    if scaler and ckpt.get('scaler'):
+    if Aemb is not None:
+        Aemb.load_state_dict(ckpt['Aemb'], strict=strict)
+    if shipemb is not None:
+        shipemb.load_state_dict(ckpt['shipemb'], strict=strict)
+    if nearemb is not None:
+        nearemb.load_state_dict(ckpt['nearemb'], strict=strict)
+    if mdl is not None:
+        mdl.load_state_dict(ckpt['model'], strict=strict)
+    if opt is not None and 'optim' in ckpt:
+        opt.load_state_dict(ckpt['optim'])
+    if scaler is not None and ckpt.get('scaler'):
         scaler.load_state_dict(ckpt['scaler'])
     return ckpt.get('epoch', 0)
 


### PR DESCRIPTION
## Summary
- redefine dataset `STEP_NODE` as maximum number of B samples
- sample B nodes evenly if voyage has more than the limit
- allow overriding parameters when resuming training

## Testing
- `python -m py_compile modelPart1/pg_dataset_eta.py modelPart1/train_eta.py modelPart1/utils.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_6840314c81ac8331ae6d94a61465544c