### PR TITLE
Fix zero division in ETA evaluation

### DIFF
--- a/modelPart1/utils.py
+++ b/modelPart1/utils.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 from typing import List, Dict
+import warnings
 logging.basicConfig(
     level=logging.ERROR,
     format="%(asctime)s %(levelname)s %(message)s",
@@ -837,6 +838,11 @@ def eval_eta(mdl,
     Aemb.train()
     shipemb.train()
     nearemb.train()
+
+    if n_seen == 0:
+        warnings.warn("Validation loader returned no samples; loss is set to 0")
+        return 0.0
+
     return tot_loss / n_seen
 
 


### PR DESCRIPTION
## Summary
- handle empty validation set in `eval_eta`
- import warnings for user notification

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68406201d7348331a63ac4bcdfaac0b9