### PR TITLE
Add confidence interval output for validation metrics

### DIFF
--- a/modelPart1/predict_suez_eta.py
+++ b/modelPart1/predict_suez_eta.py
@@ -61,8 +61,29 @@ def main():
     voy_ids = query_suez_voyage_ids(DB_DSN)
     val_loader = build_dataloader(voy_ids)
     mdl, Aemb, shipemb, nearemb = load_model(device)
-    mare, mae, rmse = eval_eta(mdl, Aemb, shipemb, nearemb, val_loader, device, criterion=torch.nn.L1Loss(), use_amp=False)
-    print(f"Suez voyages MARE: {mare:.3f}, MAE: {mae:.3f}, RMSE: {rmse:.3f}")
+    mare, mae, rmse, mare_ci, mae_ci, rmse_ci = eval_eta(
+        mdl,
+        Aemb,
+        shipemb,
+        nearemb,
+        val_loader,
+        device,
+        criterion=torch.nn.L1Loss(),
+        use_amp=False,
+    )
+    print(
+        "Suez voyages MARE: {:.3f} [{:.3f}, {:.3f}], MAE: {:.3f} [{:.3f}, {:.3f}], RMSE: {:.3f} [{:.3f}, {:.3f}]".format(
+            mare,
+            mare_ci[0],
+            mare_ci[1],
+            mae,
+            mae_ci[0],
+            mae_ci[1],
+            rmse,
+            rmse_ci[0],
+            rmse_ci[1],
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/modelPart1/train_eta.py
+++ b/modelPart1/train_eta.py
@@ -217,7 +217,24 @@ def main(cfg):
         print(f"Epoch {ep}: Train MARE {train_mare:.3f} MAE {train_mae:.3f} RMSE {train_rmse:.3f}")
         # Validation（保持不变）
         with Timer("validation"):
-            val_mare, val_mae, val_rmse = eval_eta(mdl, Aemb, shipemb, nearemb, val_dl, device, criterion, cfg.amp, news_enc)
+            (
+                val_mare,
+                val_mae,
+                val_rmse,
+                mare_ci,
+                mae_ci,
+                rmse_ci,
+            ) = eval_eta(
+                mdl,
+                Aemb,
+                shipemb,
+                nearemb,
+                val_dl,
+                device,
+                criterion,
+                cfg.amp,
+                news_enc,
+            )
         if cfg.scheduler == 'plateau':
             scheduler.step(val_mare)
         else:
@@ -225,7 +242,9 @@ def main(cfg):
 
         print(
             f"Epoch {ep}: Train MARE {train_mare:.3f} MAE {train_mae:.3f} RMSE {train_rmse:.3f}   "
-            f"Val MARE {val_mare:.3f} MAE {val_mae:.3f} RMSE {val_rmse:.3f}"
+            f"Val MARE {val_mare:.3f} [{mare_ci[0]:.3f}, {mare_ci[1]:.3f}] "
+            f"MAE {val_mae:.3f} [{mae_ci[0]:.3f}, {mae_ci[1]:.3f}] "
+            f"RMSE {val_rmse:.3f} [{rmse_ci[0]:.3f}, {rmse_ci[1]:.3f}]"
         )
 
         # Save checkpoint（保持不变）


### PR DESCRIPTION
## Summary
- compute standard deviations of validation errors
- return confidence intervals from `eval_eta`
- show CI in training output
- show CI in Suez prediction output

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840ec6d20888331ab6697bc5fbf464b